### PR TITLE
Parenthesis in metadata are optional

### DIFF
--- a/unpin/patcher.py
+++ b/unpin/patcher.py
@@ -87,6 +87,7 @@ class PatchedCondition:
 def parseVersionConstrs(versionConstrs: str) -> SpecifierSet:
 	if versionConstrs and versionConstrs[0] == "(" and versionConstrs[-1] == ")":
 		versionConstrs = versionConstrs[1:-1].strip()
+	if versionConstrs:
 		return SpecifierSet(versionConstrs, prereleases=True)
 
 	return SpecifierSet("")


### PR DESCRIPTION
This would cause unpinning to fail on some internal wheel I have.